### PR TITLE
chore: push image to both Container Registry and Artifact Registry

### DIFF
--- a/.cloudbuild/deploy.yml
+++ b/.cloudbuild/deploy.yml
@@ -1,6 +1,7 @@
 substitutions:
   # these variable are expected to remain static across environments
   _GCR_IMAGE_NAME: gcr.io/bf-container-registry/bf-product/cloud-build-notifiers
+  _ARTIFACT_REGISTRY_IMAGE_NAME: us-docker.pkg.dev/bf-artifact-registry/bf-docker-registry/bf-product/cloud-build-notifiers
 
 steps:
   - id: Docker Build
@@ -12,4 +13,5 @@ steps:
       - --build-arg=BUILD_ID=${BUILD_ID}
       - --build-arg=BUILD_SERVICE=cloudbuild
       - --destination=${_GCR_IMAGE_NAME}:${SHORT_SHA}
+      - --destination=${_ARTIFACT_REGISTRY_IMAGE_NAME}:${SHORT_SHA}
       - --cache=true


### PR DESCRIPTION
Container Registry is going away in 2025. We're migrating to Artifact Registry today. Update the `bf-product/cloud-build-notifiers` image to push to Artifact Registry and Container Registry.